### PR TITLE
Close open file descriptors and update to fs' promise API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var crc = require('crc');
-var fs = require('fs');
+var fs = require('fs/promises');
 var jBinary = require('jbinary');
 var path = require('path');
 
@@ -112,15 +112,15 @@ class VPK {
         this.directoryPath = path;
     }
 
-    isValid() {
-        let header = new Buffer(HEADER_2_LENGTH);
-        let directoryFile = fs.openSync(this.directoryPath, 'r');
-        fs.readSync(directoryFile, header, 0, HEADER_2_LENGTH, 0);
+    async isValid() {
+        let header = Buffer.alloc(HEADER_2_LENGTH);
+        const fd = await fs.open(this.directoryPath);
+        await fd.read(header, 0, HEADER_2_LENGTH, 0);
+        await (fd.close().then(() => console.log('isValid fd closed')));
         let binary = new jBinary(header, TYPESET);
 
         try {
             binary.read('vpkHeader');
-
             return true;
         }
         catch (e) {
@@ -128,8 +128,9 @@ class VPK {
         }
     }
 
-    load() {
-        let binary = new jBinary(fs.readFileSync(this.directoryPath), TYPESET);
+    async load() {
+        const directoryFileBuffer = await fs.readFile(this.directoryPath);
+        let binary = new jBinary(directoryFileBuffer, TYPESET);
 
         this.header = binary.read('vpkHeader');
         this.tree = binary.read('vpkTree');
@@ -139,18 +140,18 @@ class VPK {
         return Object.keys(this.tree);
     }
 
-    getFile(path) {
+    async getFile(path) {
         let entry = this.tree[path];
 
         if (!entry) {
             return null;
         }
 
-        let file = new Buffer(entry.preloadBytes + entry.entryLength);
+        let file = Buffer.alloc(entry.preloadBytes + entry.entryLength);
+        const directoryPathHandle = await fs.open(this.directoryPath);
 
         if (entry.preloadBytes > 0) {
-            let directoryFile = fs.openSync(this.directoryPath, 'r');
-            fs.readSync(directoryFile, file, 0, entry.preloadBytes, entry.preloadOffset);
+            await directoryPathHandle.read(file, 0, entry.preloadBytes, entry.preloadOffset);
         }
 
         if (entry.entryLength > 0) {
@@ -164,17 +165,19 @@ class VPK {
                     offset += HEADER_2_LENGTH;
                 }
 
-                let directoryFile = fs.openSync(this.directoryPath, 'r');
-                fs.readSync(directoryFile, file, entry.preloadBytes, entry.entryLength, offset + entry.entryOffset);
+                await directoryPathHandle.read(file, entry.preloadBytes, entry.entryLength, (offset + entry.entryOffset));
             }
             else {
                 let fileIndex = ('000' + entry.archiveIndex).slice(-3);
                 let archivePath = this.directoryPath.replace(/_dir\.vpk$/, '_' + fileIndex + '.vpk');
 
-                let archiveFile = fs.openSync(archivePath, 'r');
-                fs.readSync(archiveFile, file, entry.preloadBytes, entry.entryLength, entry.entryOffset);
+                const archivePathHandle = await fs.open(archivePath);
+                await archivePathHandle.read(file, entry.preloadBytes, entry.entryLength, entry.entryOffset);
+                await archivePathHandle.close();
             }
         }
+
+        await directoryPathHandle.close();
 
         if (crc.crc32(file) !== entry.crc) {
             throw new Error('CRC does not match');


### PR DESCRIPTION
Hi!

First off, thanks for releasing this module, it has helped me out a lot!
While using node-vpk I noticed that the error "EMFILE: Too many files open" would be thrown from time to time working with many VPK files. I was able to fix the error by closing the module's open file descriptors. In the mean time I upgraded to fs' promise API.

If you would like me to remove the fs promises I can do so. But to me it made more sense rewriting getFiles(...) as asynchronous since it deals with the file system.